### PR TITLE
Debug custom event listener

### DIFF
--- a/src/components/BlockReplacer.tsx
+++ b/src/components/BlockReplacer.tsx
@@ -20,12 +20,14 @@ export const BlockReplacer = ({ clientId }: { clientId: string }) => {
         replaceBlock(clientId, [blockData]).then(() => {
             const { clientId } = blockData;
             // Open the modal
-            window.dispatchEvent(
-                new CustomEvent('kevinbatdorf/stable-diffusion-open', {
-                    bubbles: true,
-                    detail: { clientId },
-                }),
-            );
+            window.requestAnimationFrame(() => {
+                window.dispatchEvent(
+                    new CustomEvent('kevinbatdorf/stable-diffusion-open', {
+                        bubbles: true,
+                        detail: { clientId },
+                    }),
+                );
+            });
         });
     }, [block, replaceBlock, clientId]);
 

--- a/src/components/BlockReplacer.tsx
+++ b/src/components/BlockReplacer.tsx
@@ -20,7 +20,6 @@ export const BlockReplacer = ({ clientId }: { clientId: string }) => {
         replaceBlock(clientId, [blockData]).then(() => {
             const { clientId } = blockData;
             // Open the modal
-            console.log('opening modal');
             window.dispatchEvent(
                 new CustomEvent('kevinbatdorf/stable-diffusion-open', {
                     bubbles: true,

--- a/src/components/BlockReplacer.tsx
+++ b/src/components/BlockReplacer.tsx
@@ -20,6 +20,7 @@ export const BlockReplacer = ({ clientId }: { clientId: string }) => {
         replaceBlock(clientId, [blockData]).then(() => {
             const { clientId } = blockData;
             // Open the modal
+            console.log('opening modal');
             window.dispatchEvent(
                 new CustomEvent('kevinbatdorf/stable-diffusion-open', {
                     bubbles: true,

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -64,6 +64,7 @@ export const Loader = ({ setAttributes, clientId }: LoaderProps) => {
     useEffect(() => {
         const namespace = 'kevinbatdorf/stable-diffusion-open';
         const open = (event: CustomEvent<{ clientId: string }>) => {
+            console.log(event?.detail?.clientId, clientId);
             if (event?.detail?.clientId !== clientId) return;
             setOpen(true);
             setShowSelectScreen(true);

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -64,7 +64,6 @@ export const Loader = ({ setAttributes, clientId }: LoaderProps) => {
     useEffect(() => {
         const namespace = 'kevinbatdorf/stable-diffusion-open';
         const open = (event: CustomEvent<{ clientId: string }>) => {
-            console.log(event?.detail?.clientId, clientId);
             if (event?.detail?.clientId !== clientId) return;
             setOpen(true);
             setShowSelectScreen(true);

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -145,7 +145,7 @@ const ContentWrapper = ({
             </div>
             <ModalCloseButton onClose={onClose} />
         </div>
-        <div className="overflow-y-scroll md:flex flex-grow w-screen max-w-full pt-20 md:pt-0 bg-gray-50 divide-x">
+        <div className="overflow-y-scroll md:flex flex-grow w-screen max-w-full h-screen md:h-auto pt-20 md:pt-0 bg-gray-50 divide-x">
             {children}
         </div>
     </>

--- a/stable-diffusion.php
+++ b/stable-diffusion.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name:       Block Diffusion - Image AI Generation
+ * Plugin Name:       Block Diffusion
  * Description:       AI Image Generation from text prompts using the Replicate API.
  * Requires at least: 5.8
  * Requires PHP:      7.0

--- a/stable-diffusion.php
+++ b/stable-diffusion.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:       Block Diffusion
- * Description:       AI Image Generation from text prompts using the Replicate API.
+ * Description:       Generate unique images from text prompts using machine learning, all in the cloud.
  * Requires at least: 5.8
  * Requires PHP:      7.0
  * Version:           0.1.1


### PR DESCRIPTION
The event listener checks for the client ID, but on mobile, for some reason, the image block isn't yet injected by the time the event fires. Seems like a Gutenberg bug. This PR waits for the next frame to pass.