### PR TITLE
Force logout when 401 on model info endpoint

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -26,8 +26,8 @@ export const Login = ({ initialFocus }: LoginProps) => {
         }
     }, [success, storeApiToken, token]);
 
-    console.log('error', error);
     if (error) {
+        console.error(error);
         setErrorMsg(() => {
             // Replicate error
             if (error?.detail) return error.detail;

--- a/src/hooks/useModel.ts
+++ b/src/hooks/useModel.ts
@@ -14,10 +14,16 @@ const fetcher = (
     });
 
 export const useModel = (model: AvailableModels) => {
-    const { apiToken } = useAuthStore();
+    const { apiToken, storeApiToken } = useAuthStore();
     const { data, error } = useSWRImmutable<ModelData>(
         [model, apiToken],
         fetcher,
     );
+    // check if error is 401
+    if (error?.detail === 'Invalid token.') {
+        console.error(error);
+        storeApiToken('');
+    }
+
     return { data, error, loading: !error && !data };
 };


### PR DESCRIPTION
This will redirect the user to the login page if the model check fails. If the key changes when the modal is already open, they will see a warning when they attempt to run a prompt.