### PR TITLE
Get token from db if not present

### DIFF
--- a/php/router.php
+++ b/php/router.php
@@ -12,8 +12,7 @@ if (!class_exists('KBSDRouter')) {
                 }
                 if (!$request->get_header('authorization')) {
                     // Users have reported the headers being stripped out of the request
-                    $token = $this->findAuthToken($request);
-                    $request->set_header('authorization', $token);
+                    $request->set_header('authorization', $this->findAuthToken($request));
                 }
                 // If the api token is in the body, remove it
                 $body = json_decode($request->get_body(), true);

--- a/php/router.php
+++ b/php/router.php
@@ -5,6 +5,26 @@ if (!class_exists('KBSDRouter')) {
     class KBSDRouter extends \WP_REST_Controller
     {
         protected static $instance = null;
+        public function __construct() {
+            \add_filter('rest_request_before_callbacks', function ($response, $handler, $request) {
+                if (!strpos($request->get_route(), 'stable-diffusion')) {
+                    return $response;
+                }
+                if (!$request->get_header('authorization')) {
+                    // Users have reported the headers being stripped out of the request
+                    $token = $this->findAuthToken($request);
+                    $request->set_header('authorization', $token);
+                }
+                // If the api token is in the body, remove it
+                $body = json_decode($request->get_body(), true);
+                if (isset($body['apiToken'])) {
+                    unset($body['apiToken']);
+                    $request->set_body(json_encode($body));
+                }
+                return $response;
+            }, 10, 3);
+        }
+
         public function getHandler($namespace, $endpoint, $callback) {
             \register_rest_route(
                 $namespace,
@@ -39,6 +59,19 @@ if (!class_exists('KBSDRouter')) {
             }
             $r = self::$instance;
             return $r->$name('kevinbatdorf/stable-diffusion', ...$arguments);
+        }
+
+        private function findAuthToken($request) {
+            $options = \get_option('stable_diffusion_settings', ['apiToken' => '']);
+            $hasToken = isset($options['apiToken']) && $options['apiToken'];
+            $token = $hasToken ? "Token {$options['apiToken']}" : '';
+            // If not in options, check for token in request body
+            if (!$hasToken) {
+                $params = $request->get_params();
+                $hasToken = isset($params['apiToken']) && $params['apiToken'];
+                $token = $hasToken ? "Token {$params['apiToken']}" : '';
+            }
+            return $token;
         }
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -52,6 +52,8 @@ This plugin provides an interface to the Replicate API and requires you have an 
 
 == Changelog ==
 
+- Tweak: Add middleware to grab token from the db (or body)
+
 = 0.1.7 - 2022-09-15 =
 - Update auto inject to be more reliable
 - Tweak styling to avoid some theme conflicts

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -8,6 +8,7 @@ const fetcher = async (apiToken: string) => {
         method: 'POST',
         path: `kevinbatdorf/stable-diffusion/login?cache=${Date.now()}`,
         headers: { Authorization: `Token ${apiToken}` },
+        data: { apiToken },
     });
     // If it doesn't throw, it's good
     return true;

--- a/src/models/StableDiffusion.tsx
+++ b/src/models/StableDiffusion.tsx
@@ -72,7 +72,7 @@ export const StableDiffusion = ({
         const response = await apiFetch<GenerateResponse>({
             path: `kevinbatdorf/stable-diffusion/generate?cache=${Date.now()}`,
             method: 'POST',
-            headers: { Authorization: `Token ${apiToken}` },
+            // headers: { Authorization: `Token ${apiToken}` },
             data: {
                 input: { width, height, prompt },
                 version: modelInfo.latest_version.id,

--- a/src/models/StableDiffusion.tsx
+++ b/src/models/StableDiffusion.tsx
@@ -72,7 +72,7 @@ export const StableDiffusion = ({
         const response = await apiFetch<GenerateResponse>({
             path: `kevinbatdorf/stable-diffusion/generate?cache=${Date.now()}`,
             method: 'POST',
-            // headers: { Authorization: `Token ${apiToken}` },
+            headers: { Authorization: `Token ${apiToken}` },
             data: {
                 input: { width, height, prompt },
                 version: modelInfo.latest_version.id,


### PR DESCRIPTION
Or from the body if its not in the db (e.g. the /login request)

It was reported by someone that their auth headers were being stripped out, possibly by their hosting provider or another plugin? This is hopefully a good solution