### PR TITLE
Update Cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,9 +2,9 @@ name: Run Cypress test suite
 on:
     pull_request:
     workflow_dispatch:
-    # schedule:
+    schedule:
     # At 08:00 on Thursday.
-    # - cron: "0 8 * * 4"
+    - cron: "0 8 * * 4"
 jobs:
     test:
         name: Cypress
@@ -14,7 +14,7 @@ jobs:
                 wp-version: [null, '"WordPress/WordPress#master"']
         steps:
             - name: Clone repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - name: Install server
               run: |
                   npm ci
@@ -22,7 +22,7 @@ jobs:
                   npm run build
                   rm .wp-env.json
             - name: Change WP version
-              uses: jsdaniell/create-json@1.1.2
+              uses: jsdaniell/create-json@v1.2.1
               with:
                   name: 'wp-env.json'
                   json: '{"core": ${{ matrix.wp-version }},"plugins":["."]}'

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,3 +1,4 @@
+import 'cypress-wait-until';
 import './commands';
 import './globals';
 import './helpers';

--- a/cypress/support/gutenberg.js
+++ b/cypress/support/gutenberg.js
@@ -1,12 +1,38 @@
 export const closeWelcomeGuide = () => {
     cy.window().then((win) => {
-        if (
-            win.wp.data.select('core/edit-post').isFeatureActive('welcomeGuide')
-        ) {
+        // If it's not open, open it first
+        cy.waitUntil(() => {
+            if (
+                win.wp.data
+                    .select('core/edit-post')
+                    .isFeatureActive('welcomeGuide')
+            ) {
+                return true;
+            }
             win.wp.data
                 .dispatch('core/edit-post')
                 .toggleFeature('welcomeGuide');
-        }
+            return false;
+        });
+        const className = '[aria-label="Welcome to the block editor"]';
+        // It's important we open it then wait for the animation to finish
+        cy.get(className).should('be.visible');
+        // Then close it
+        cy.waitUntil(() => {
+            if (
+                !win.wp.data
+                    .select('core/edit-post')
+                    .isFeatureActive('welcomeGuide')
+            ) {
+                return true;
+            }
+            win.wp.data
+                .dispatch('core/edit-post')
+                .toggleFeature('welcomeGuide');
+
+            // And wait again for the animation to finish
+            cy.get(className).should('not.exist');
+        });
     });
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
                 "@wordpress/url": "^3.19.0",
                 "autoprefixer": "^10.4.12",
                 "cypress": "^10.9.0",
+                "cypress-wait-until": "^1.7.2",
                 "dotenv": "^16.0.3",
                 "eslint": "^8.24.0",
                 "eslint-config-prettier": "^8.5.0",
@@ -9432,6 +9433,12 @@
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/cypress-wait-until": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
+            "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
+            "dev": true
         },
         "node_modules/cypress/node_modules/@types/node": {
             "version": "14.18.28",
@@ -31623,6 +31630,12 @@
                     "dev": true
                 }
             }
+        },
+        "cypress-wait-until": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
+            "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
+            "dev": true
         },
         "damerau-levenshtein": {
             "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "plugin-zip": "wp-scripts plugin-zip",
         "start": "wp-scripts start",
         "eject": "node scripts/eject.mjs",
-        "rename": "node scripts/rename.mjs"
+        "rename": "node scripts/rename.mjs",
+        "env:refresh": "yes | wp-env destroy && wp-env start --update"
     },
     "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^3.3.0",
@@ -29,6 +30,7 @@
         "@wordpress/url": "^3.19.0",
         "autoprefixer": "^10.4.12",
         "cypress": "^10.9.0",
+        "cypress-wait-until": "^1.7.2",
         "dotenv": "^16.0.3",
         "eslint": "^8.24.0",
         "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
This updates the Cypress tests to run better on WordPress (and updates some old GH actions)