### PR TITLE
Update number input

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,7 @@
         "space-in-parens": ["error", "never"],
         "key-spacing": ["error", { "afterColon": true }],
         "space-infix-ops": ["error"],
+        "@typescript-eslint/no-unused-vars": ["error"],
         "space-before-function-paren": [
             "error",
             {

--- a/src/components/InputGenerator.tsx
+++ b/src/components/InputGenerator.tsx
@@ -74,7 +74,6 @@ export const InputGenerator = ({ inputsData, disabled }: Props) => {
                         value={numOutputs}
                         disabled={disabled}
                         onChange={(v) => setInput('numOutputs', v)}
-                        // get range from minimum to maximum
                         options={Array.from(
                             {
                                 length:

--- a/src/components/InputGenerator.tsx
+++ b/src/components/InputGenerator.tsx
@@ -13,7 +13,7 @@ type Props = {
 };
 export const InputGenerator = ({ inputsData, disabled }: Props) => {
     const { width, height, prompt, numOutputs, setInput } = useInputsState();
-
+    console.log({ inputsData });
     useEffect(() => {
         setInput('width', inputsData?.width?.default ?? 512);
         setInput('height', inputsData?.height?.default ?? 512);
@@ -74,7 +74,16 @@ export const InputGenerator = ({ inputsData, disabled }: Props) => {
                         value={numOutputs}
                         disabled={disabled}
                         onChange={(v) => setInput('numOutputs', v)}
-                        options={inputsData?.numOutputs?.enum ?? [1]}
+                        // get range from minimum to maximum
+                        options={Array.from(
+                            {
+                                length:
+                                    inputsData?.numOutputs?.maximum -
+                                    inputsData?.numOutputs?.minimum +
+                                    1,
+                            },
+                            (_, i) => i + 1,
+                        )}
                     />
                 )}
             </div>

--- a/src/components/InputGenerator.tsx
+++ b/src/components/InputGenerator.tsx
@@ -13,7 +13,7 @@ type Props = {
 };
 export const InputGenerator = ({ inputsData, disabled }: Props) => {
     const { width, height, prompt, numOutputs, setInput } = useInputsState();
-    console.log({ inputsData });
+
     useEffect(() => {
         setInput('width', inputsData?.width?.default ?? 512);
         setInput('height', inputsData?.height?.default ?? 512);

--- a/src/components/UserInterface.tsx
+++ b/src/components/UserInterface.tsx
@@ -1,5 +1,4 @@
 import apiFetch from '@wordpress/api-fetch';
-import { Icon, Tooltip } from '@wordpress/components';
 import { Spinner } from '@wordpress/components';
 import {
     useEffect,
@@ -20,7 +19,6 @@ import {
     AvailableModels,
     HeightInput,
     ImageLike,
-    NumOutputsInput,
     InputsData,
     WidthInput,
     PredictionData,
@@ -182,12 +180,10 @@ export const UserInferface = ({
         const maybeHeight = inputs?.height
             ? schema.components.schemas.height
             : undefined;
-        const maybeNumOutputs = inputs?.num_outputs
-            ? schema.components.schemas.num_outputs
-            : undefined;
         setPromptInputData({
             prompt: inputs?.prompt,
             initImage: inputs?.init_image,
+            numOutputs: inputs?.num_outputs,
             width: maybeWidth
                 ? {
                       ...(maybeWidth as WidthInput),
@@ -198,12 +194,6 @@ export const UserInferface = ({
                 ? {
                       ...(maybeHeight as HeightInput),
                       default: inputs?.height?.default,
-                  }
-                : undefined,
-            numOutputs: maybeNumOutputs
-                ? {
-                      ...(maybeNumOutputs as NumOutputsInput),
-                      default: inputs?.num_outputs?.default,
                   }
                 : undefined,
         });

--- a/src/components/features/PromptGenerator.tsx
+++ b/src/components/features/PromptGenerator.tsx
@@ -1,5 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
-import { Icon, Tooltip, Popover, ToggleControl } from '@wordpress/components';
+import { Icon, Tooltip, ToggleControl } from '@wordpress/components';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Dialog } from '@headlessui/react';

--- a/src/components/inputs/MediaUploader.tsx
+++ b/src/components/inputs/MediaUploader.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@wordpress/components';
-import { Button, Spinner } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { MediaUpload as MeidiaLibrary } from '@wordpress/media-utils';
@@ -28,6 +28,8 @@ export const MediaUploader = ({ disabled }: MediaUploaderProps) => {
         <MediaUploadCheck>
             <MeidiaLibrary
                 title={__('Select Image', 'stable-diffusion')}
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore-next-line
                 onSelect={onUpdateImage}
                 allowedTypes={['image']}
                 modalClass=""

--- a/src/layouts/DialogWithImage.tsx
+++ b/src/layouts/DialogWithImage.tsx
@@ -1,4 +1,3 @@
-import { __ } from '@wordpress/i18n';
 import { Dialog } from '@headlessui/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ModalCloseButton } from '../components/ModalControls';

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,7 +116,8 @@ export type HeightInput = {
 export type NumOutputsInput = {
     default?: number;
     description: string;
-    enum: number[];
+    minimum: number;
+    maximum: number;
     title: string;
     type: string;
 };
@@ -131,7 +132,8 @@ export type OpenApiSchema = {
             Input: {
                 properties: {
                     prompt?: PromptInput;
-                    init_image?: InitImagePrompt;
+                    init_image?: InitImageInput;
+                    num_outputs?: NumOutputsInput;
                     width?: {
                         default: number;
                         description: string;
@@ -140,13 +142,6 @@ export type OpenApiSchema = {
                         }[];
                     };
                     height?: {
-                        default: number;
-                        description: string;
-                        allOf: {
-                            $ref: string;
-                        }[];
-                    };
-                    num_outputs?: {
                         default: number;
                         description: string;
                         allOf: {


### PR DESCRIPTION
This updates the `num_inputs` which replicate updated to use a range instead of an enum. I removed support for the enum but it may be worth adding it back in case they switch it again.